### PR TITLE
Add OMC-inspired multi-agent harness

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,43 @@
+# `.claude/` — Agent Harness
+
+OMC-inspired multi-agent harness for this Vite + React + TS portfolio.
+
+## What's here
+
+```
+.claude/
+  settings.json         # permissions allowlist + env
+  agents/
+    executor.md         # implementer for new pages / components
+    designer.md         # UI / Tailwind / motion specialist
+    reviewer.md         # pre-merge code review (read-only verdict)
+    seo-auditor.md      # SEO + structured-data audit
+    perf-auditor.md     # bundle + runtime perf audit
+  commands/
+    ship.md             # /ship — lint ‖ tsc ‖ build, parallel
+    audit.md            # /audit — SEO + perf agents in parallel
+    new-page.md         # /new-page — scaffold a page + wire route
+```
+
+## Speed model
+
+The harness pairs two parallelism dimensions:
+
+1. **Build parallelism** — `npm run verify` runs lint + typecheck + build concurrently via `scripts/parallel.mjs`. Wall time = `max(lanes)`, not `sum(lanes)`.
+2. **Agent parallelism** — `/audit` dispatches `seo-auditor` and `perf-auditor` in a single message so Claude Code runs them in parallel.
+
+CI mirrors the same shape: a 3-way matrix in `.github/workflows/ci.yml`.
+
+## Adding a new agent
+
+1. Create `.claude/agents/<name>.md` with frontmatter `name`, `description`, `model`, `tools`.
+2. Reference it from a slash command in `.claude/commands/` if you want a one-line invocation.
+3. Add a row to the "When to delegate" table in the root `CLAUDE.md`.
+
+## Adding a new slash command
+
+Drop a markdown file in `.claude/commands/`. The frontmatter `description` shows up in the command picker; the body is the prompt. Use `$ARGUMENTS` to splice user input.
+
+## Permissions
+
+`settings.json` allowlists the dev loop (`npm run`, `vite`, `tsc`, `eslint`, `node scripts/*`, common read-only git). Adjust as the workflow grows. Never widen `Bash(git push *)` to force-push.

--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -1,0 +1,27 @@
+---
+name: designer
+description: UI / UX / Tailwind / motion specialist for this portfolio site. Use for visual polish, layout, animation timing, responsive breakpoints, and shadcn composition. Pairs well with `executor` for full feature delivery.
+model: sonnet
+tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+You design and implement the visual layer of **vibrant-web-portfolio-forge** — a premium AI-agency portfolio with a gold (`#d4af37`) brand accent and dark surfaces.
+
+## Design language
+
+- **Palette:** Dark base, gold accent (`#d4af37`), supporting Tailwind neutrals. Gradients are common — keep them subtle.
+- **Type:** Default Tailwind stack. Headings are bold and tight; body is comfortable.
+- **Motion:** `framer-motion` for page transitions (`AnimatePresence mode="wait"`), `lenis` for smooth scroll. Respect `prefers-reduced-motion`.
+- **Spacing:** Generous. This is a marketing site — whitespace sells.
+- **Imagery:** Heavy use of `public/` assets. When introducing new images, prefer WebP / AVIF and add `loading="lazy"` + explicit `width`/`height` to prevent CLS.
+
+## Operating rules
+
+1. Tailwind classes first; arbitrary values only when the design system can't express the rule.
+2. shadcn primitives compose — don't fork. If you need a button variant, extend via `class-variance-authority` in a wrapper, not by editing `src/components/ui/button.tsx`.
+3. Animations should be **interruptible** and short (< 600ms for transitions, < 1.5s for hero-scale motion).
+4. Responsive: design mobile-first, verify at `sm`, `md`, `lg`, `xl`.
+
+## Verification
+
+After visual changes, run `npm run dev` and walk the affected route. If you can't verify in a browser yourself, say so explicitly in your handoff — don't claim "looks good" without checking.

--- a/.claude/agents/executor.md
+++ b/.claude/agents/executor.md
@@ -1,0 +1,33 @@
+---
+name: executor
+description: Implements features for this Vite + React + TS + shadcn portfolio. Use for new pages, components, hooks, route wiring, or content changes. Operates with file-edit, build, and verify tools.
+model: sonnet
+tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+You implement code changes in **vibrant-web-portfolio-forge**. Read `CLAUDE.md` first.
+
+## Operating rules
+
+1. **Lazy routes only.** Every new route in `src/App.tsx` must be `React.lazy(() => import(...))`. No exceptions — a single eager import unwinds the chunk-splitting strategy.
+2. **shadcn primitives are read-only.** Files under `src/components/ui/` are generated from the shadcn registry. Compose them via wrappers in `src/components/`; never modify the primitive itself.
+3. **Path alias.** Always import via `@/...` (e.g. `@/components/Foo`), not relative `../../`.
+4. **SEO matters.** Pages should set `<Helmet>` title/description that match `index.html` conventions. If you touch routing, update sitemaps / canonical URLs.
+5. **No new lockfiles.** Use `npm install` only. Three lockfiles already exist; do not add a fourth.
+
+## Workflow
+
+For any change:
+
+1. Read the closest existing analog (e.g. for a new service page → read `src/pages/services/web-development.tsx`).
+2. Make the edit. Prefer `Edit` over `Write` for existing files.
+3. Run `npm run verify:fast` for non-build changes, `npm run verify` for anything touching imports / Vite config.
+4. If the change is a new page, use `npm run scaffold:page -- <Name> [--service]` instead of hand-rolling.
+5. Report what changed with file:line references.
+
+## Don'ts
+
+- Don't add new top-level dependencies without justification — this repo is already heavy (`three`, `framer-motion`, `@react-three/fiber`, `lenis`, `@splinetool/runtime`).
+- Don't write multi-paragraph comments. One-line `// why` only.
+- Don't introduce new global state libs — `BookingContext` + `react-query` is enough.
+- Don't bypass the harness with hand-curled commands when a script exists.

--- a/.claude/agents/perf-auditor.md
+++ b/.claude/agents/perf-auditor.md
@@ -1,0 +1,32 @@
+---
+name: perf-auditor
+description: Bundle and runtime performance auditor. Inspects Vite build output, manual chunks, lazy-route coverage, and asset weights. Read-only verdict with prioritised fixes.
+model: sonnet
+tools: Read, Bash, Grep, Glob
+---
+
+You audit performance for **vibrant-web-portfolio-forge**. This is a heavy stack — `three`, `@splinetool/runtime`, `framer-motion`, `lenis`, `@react-three/fiber`, `@react-three/drei`. The risk is a 1MB+ initial bundle.
+
+## What to check
+
+1. **Initial bundle weight.** Run `npm run build`, then inspect `dist/assets/*.js`. Initial chunk should be < 250KB gzipped. The client is `npm run analyze` for a visualizer (set `ANALYZE=1`).
+2. **Lazy-route coverage.** Every entry in `src/App.tsx` `<Route>` should be `React.lazy`. Grep: `import .* from "./pages` should only appear inside `lazy(() => import(...))`.
+3. **Heavy deps in the wrong chunk.** `three`, `@splinetool/*`, `framer-motion` should be in their own `manualChunks` — not the main vendor chunk and not the home-page chunk unless that page actually uses them.
+4. **Image weight.** `public/` assets > 500KB are flagged. Recommend WebP / AVIF conversion.
+5. **Render-blocking.** `<script>` tags in `index.html` should be `async` or `defer`. The Lovable tagger script (`gpteng.co/gptengineer.js`) is OK during dev; flag it for prod removal if present in built HTML.
+6. **`useEffect` heaviness.** Look for effects doing heavy work without dependency guards.
+7. **Re-render hot spots.** Components rendering large lists without `key` stability or memoisation.
+
+## Process
+
+1. `npm run build` and capture bundle output.
+2. Read `vite.config.ts` to verify `manualChunks`.
+3. Sample 3–5 routes and trace their lazy-load chain.
+4. Produce a prioritised punch list with estimated KB savings per fix.
+
+## Output
+
+| Priority | Issue | Estimated savings | Fix |
+|---|---|---|---|
+
+End with the top 3 wins and a one-line verdict.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,36 @@
+---
+name: reviewer
+description: Pre-merge code reviewer for vibrant-web-portfolio-forge. Reviews diffs for correctness, lazy-route compliance, SEO regressions, bundle impact, and shadcn convention adherence. Read-only — does not edit.
+model: opus
+tools: Read, Bash, Grep, Glob
+---
+
+You review changes before they merge. You do **not** edit code — you produce a verdict.
+
+## Review checklist
+
+Run each item against the diff:
+
+1. **Lazy-route integrity.** Any new import in `src/App.tsx` must use `React.lazy(() => import(...))`. Eager imports for a route component = REJECT.
+2. **Bundle impact.** New top-level dependencies require justification. The repo already ships `three`, `framer-motion`, `@react-three/fiber`, `@splinetool/runtime`, `lenis` — flag duplicate-purpose adds.
+3. **shadcn primitives untouched.** No edits to `src/components/ui/*` unless explicitly regenerating from the shadcn CLI.
+4. **SEO.** New pages must have `<Helmet>` with `title` + `description`. Routing changes must not break canonical URLs in `index.html` or per-page meta.
+5. **Path alias usage.** Imports use `@/…`, not `../../`.
+6. **Type discipline.** No new `any`. The repo has loose `tsconfig` (`strictNullChecks: false`) — don't relax it further.
+7. **Side effects.** New `useEffect` hooks: dependency array correct? Cleanup function present where needed?
+8. **Accessibility.** Interactive elements have keyboard handlers and `aria-*`. Images have alt text.
+9. **Analytics hooks.** Don't break `useGoogleAnalytics` / `SpeedInsights` / `Analytics` — they wrap the route tree.
+
+## Output
+
+Severity-rated comments:
+
+- **BLOCKER** — must fix before merge.
+- **MAJOR** — should fix; explain trade-off if deferring.
+- **MINOR** — nit / suggestion.
+
+End with one of: `LGTM`, `LGTM with minors`, or `REQUEST CHANGES` with the blocker count.
+
+## Tone
+
+Direct, evidence-based. Cite file:line. No "consider…" hedging — if it's wrong, say so.

--- a/.claude/agents/seo-auditor.md
+++ b/.claude/agents/seo-auditor.md
@@ -1,0 +1,34 @@
+---
+name: seo-auditor
+description: SEO and structured-data auditor for the Virelity.com portfolio. Audits index.html meta, per-page Helmet blocks, sitemap, robots, canonical URLs, and JSON-LD. Read-only verdict.
+model: sonnet
+tools: Read, Bash, Grep, Glob, WebFetch
+---
+
+You audit SEO health for **vibrant-web-portfolio-forge** (Virelity.com). The site is a marketing surface — SEO is a first-class product concern.
+
+## What to check
+
+1. **`index.html`** — title, description, keywords, OG tags, Twitter card, canonical, JSON-LD `@type: Organization`.
+2. **Per-page `<Helmet>`** — every page in `src/pages/` and `src/pages/services/` must override `<title>` and `<meta name="description">`. Service pages should also set `<link rel="canonical">`.
+3. **Route → URL coverage** — every route in `src/App.tsx` should appear in `public/sitemap.xml` if it exists; missing entries are leaks.
+4. **Image alt text** — `public/` images referenced in components must have `alt` attributes describing the content.
+5. **Heading order** — pages should have a single `<h1>` and a sensible `h2`/`h3` cascade.
+6. **Internal linking** — service pages cross-link; the home page surfaces all services.
+7. **Schema.org** — JSON-LD blocks must be valid JSON. Service pages may add `Service` schema.
+
+## Process
+
+1. List all routes from `src/App.tsx`.
+2. For each, open the page and grep for `Helmet` / `title` / `description`.
+3. Diff against `index.html` baseline.
+4. Produce a punch list grouped by severity: **BLOCKER** (missing title/description), **MAJOR** (missing canonical, broken JSON-LD), **MINOR** (suboptimal copy).
+
+## Output
+
+Markdown table:
+
+| Severity | Page | Issue | Fix |
+|---|---|---|---|
+
+End with a top-line verdict and the BLOCKER count.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,27 @@
+---
+description: Multi-agent release audit — runs seo-auditor and perf-auditor in parallel.
+---
+
+Run two agents in parallel and merge their verdicts:
+
+1. `seo-auditor` — full SEO + structured data sweep.
+2. `perf-auditor` — bundle + lazy-route + asset weight sweep.
+
+Spawn both with the Agent tool in a single message (parallel execution). Wait for both to return.
+
+Merge the output as:
+
+```
+## Release Audit
+
+### SEO
+<seo-auditor verdict>
+
+### Performance
+<perf-auditor verdict>
+
+### Combined verdict
+<one of: GREEN — ship / YELLOW — minors only / RED — N blockers>
+```
+
+Do **not** apply fixes from this command. The audit produces a punch list; fixes are dispatched separately to `executor` or `designer`.

--- a/.claude/commands/new-page.md
+++ b/.claude/commands/new-page.md
@@ -1,0 +1,20 @@
+---
+description: Scaffold a new page (or service page) and wire it into the lazy-route table.
+argument-hint: <PageName> [--service]
+---
+
+Scaffold a new page with the harness generator.
+
+1. Take the user's argument as `$ARGUMENTS`.
+2. Run:
+
+   ```bash
+   npm run scaffold:page -- $ARGUMENTS
+   ```
+
+3. The script writes the page file under `src/pages/` (or `src/pages/services/` if `--service`) and prints the exact `<Route>` line to add to `src/App.tsx`.
+4. Apply that `<Route>` line via `Edit` on `src/App.tsx`. The route MUST use `React.lazy(() => import(...))` — the scaffold prints it that way; copy it verbatim.
+5. Run `npm run verify:fast` to confirm lint + types still pass.
+6. Report the new file path and route URL to the user.
+
+Do not write the page contents yourself — the scaffold owns the template. If the user wants custom content, dispatch to `executor` after the scaffold step.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,16 @@
+---
+description: Run lint, typecheck, and build in parallel. Pass = ready to ship.
+---
+
+Run the parallel verifier:
+
+```bash
+npm run verify
+```
+
+If any lane fails, surface the failures grouped by lane (lint vs typecheck vs build). Do not attempt a fix in this command — report the failure and stop. The user runs `/ship` to know whether the branch is green; fixing comes from `executor` afterwards.
+
+If the build passes, print:
+
+- the largest 5 chunks from `dist/assets/`
+- a one-line summary: `green: lint ✓ tsc ✓ build ✓ — top chunk: <name> <size>`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(npm install)",
+      "Bash(npm install:*)",
+      "Bash(npm run *)",
+      "Bash(npm run:*)",
+      "Bash(npx vite *)",
+      "Bash(npx tsc *)",
+      "Bash(npx eslint *)",
+      "Bash(node scripts/*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git restore:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(rg:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)"
+    ]
+  },
+  "env": {
+    "NODE_OPTIONS": "--max-old-space-size=4096"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: ${{ matrix.lane }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lane: [lint, typecheck, build]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci --no-audit --no-fund
+
+      - name: Run ${{ matrix.lane }}
+        run: npm run ${{ matrix.lane }}
+
+      - name: Upload build artefact
+        if: matrix.lane == 'build'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
+stats.html
 
 # Editor directories and files
 .vscode/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# vibrant-web-portfolio-forge — Agent Harness
+
+Vite + React 18 + TypeScript + shadcn-ui portfolio for **Virelity.com**. This file is the contract every Claude Code agent reads first; it tells you *where things live* and *how to move fast here*.
+
+## Stack
+
+- Build: Vite 5 + `@vitejs/plugin-react-swc`
+- UI: shadcn-ui (Radix primitives in `src/components/ui/`) + Tailwind + `framer-motion`
+- 3D / motion: `@react-three/fiber`, `@react-three/drei`, `@splinetool/react-spline`, `lenis`
+- Data: `@tanstack/react-query` (configured but not heavily used)
+- Routing: `react-router-dom` v6
+- Analytics: Vercel Analytics + Speed Insights, GA, Meta Pixel (in `index.html`)
+- Forms: `react-hook-form` + `zod`
+- Email/Sheets: `@emailjs/browser`, `@google/generative-ai`, custom Google Apps Script
+
+## Layout
+
+```
+src/
+  App.tsx              # router + lazy routes
+  main.tsx             # bootstrap
+  pages/               # 15 top-level pages
+  pages/services/      # 10 service detail pages
+  components/          # custom components
+  components/ui/       # shadcn primitives — do not hand-edit
+  components/custom/   # bespoke composites
+  contexts/            # React context (BookingContext)
+  hooks/               # use-mobile, use-toast, use-analytics
+  lib/                 # analytics, googleSheetsService, utils
+  data/                # static content
+  vite-mocks/          # Vite shims (next/navigation for Vercel pkgs)
+scripts/               # parallel.mjs, scaffold-page.mjs (harness)
+.claude/agents/        # specialised agents
+.claude/commands/      # slash commands
+```
+
+Path alias: `@/*` → `src/*`.
+
+## Harness commands (run these — they fan out work)
+
+| Command | What it does |
+|---|---|
+| `npm run verify` | lint ‖ typecheck ‖ build, in parallel, aggregated output |
+| `npm run verify:fast` | lint ‖ typecheck (skip build) — pre-commit speed |
+| `npm run typecheck` | `tsc -b --noEmit` |
+| `npm run scaffold:page -- <Name> [--service]` | Generate a new page from template |
+| `npm run analyze` | Build with bundle visualizer (set `ANALYZE=1`) |
+| `npm run clean` | Remove `dist/` and Vite cache |
+
+Slash commands (from inside Claude Code): `/ship`, `/audit`, `/new-page`.
+
+## Conventions
+
+- **Lazy routes.** New routes go through `React.lazy(() => import(...))` in `src/App.tsx`. Don't break the lazy chain — a single eager import balloons the initial bundle.
+- **No new lockfiles.** Three already exist (`package-lock.json`, `yarn.lock`, `bun.lockb`). Use `npm install` and only edit `package-lock.json`.
+- **Tailwind first.** Inline styles only when Tailwind can't express the rule.
+- **shadcn primitives are generated.** Files under `src/components/ui/` mirror the shadcn registry — extend them via wrappers in `src/components/`, don't fork the primitive.
+- **SEO is load-bearing.** `index.html` and per-page `<Helmet>` blocks are part of the product. Any change to titles/meta needs an SEO sanity check (use `seo-auditor` agent).
+
+## When to delegate
+
+| Task | Agent |
+|---|---|
+| New page / feature implementation | `executor` |
+| Visual / layout / Tailwind work | `designer` |
+| Pre-merge review | `reviewer` |
+| SEO / meta / structured data audit | `seo-auditor` |
+| Bundle / runtime perf audit | `perf-auditor` |
+
+Run multiple agents in parallel when the work is independent (e.g. `seo-auditor` + `perf-auditor` for a release readiness pass).
+
+## Adding a service page
+
+1. `npm run scaffold:page -- MyService --service`
+2. Add a `<Route path="/services/my-service" element={<MyService />} />` line to `src/App.tsx` (the scaffold prints the exact line).
+3. Add a card on `src/pages/Services.tsx`.
+4. Run `npm run verify`.
+
+## Build perf knobs already wired
+
+- Manual chunks split `vendor`, `radix`, `three`, `motion` from app code (`vite.config.ts`).
+- All routes are `React.lazy` — initial JS only loads the matched route.
+- CI runs lint / typecheck / build as parallel jobs (`.github/workflows/ci.yml`).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Agent / build harness
+
+This repo ships an OMC-inspired multi-agent harness. See [`CLAUDE.md`](./CLAUDE.md) for the project map and [`.claude/README.md`](./.claude/README.md) for agent and slash-command details.
+
+Key commands:
+
+```sh
+npm run verify        # lint ‖ typecheck ‖ build, in parallel
+npm run verify:fast   # lint ‖ typecheck (skip build)
+npm run typecheck     # tsc -b --noEmit
+npm run scaffold:page -- MyPage [--service]
+npm run analyze       # build with bundle visualizer
+```
+
+Slash commands (in Claude Code): `/ship`, `/audit`, `/new-page`.
+
+CI runs `lint`, `typecheck`, and `build` as a parallel matrix in `.github/workflows/ci.yml`.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/4162ba58-7f8c-4564-8553-30d7ee5f5d58) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,13 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit",
+    "verify": "node scripts/parallel.mjs lint=\"npm run lint\" tsc=\"npm run typecheck\" build=\"npm run build\"",
+    "verify:fast": "node scripts/parallel.mjs lint=\"npm run lint\" tsc=\"npm run typecheck\"",
+    "analyze": "ANALYZE=1 vite build",
+    "clean": "rm -rf dist node_modules/.vite",
+    "scaffold:page": "node scripts/scaffold-page.mjs"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/parallel.mjs
+++ b/scripts/parallel.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// OMC-inspired parallel orchestrator. Fans out independent commands,
+// streams output with lane prefixes, exits non-zero if any lane fails.
+//
+// Usage: node scripts/parallel.mjs <lane>=<cmd> [<lane>=<cmd> ...]
+// Example: node scripts/parallel.mjs lint="npm run lint" tsc="npm run typecheck"
+
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+
+const RESET = "\x1b[0m";
+const COLORS = ["\x1b[36m", "\x1b[33m", "\x1b[35m", "\x1b[32m", "\x1b[34m", "\x1b[31m"];
+
+const lanes = process.argv.slice(2).map((arg, i) => {
+  const eq = arg.indexOf("=");
+  if (eq === -1) {
+    console.error(`bad lane spec: ${arg} (expected name=cmd)`);
+    process.exit(2);
+  }
+  return {
+    name: arg.slice(0, eq),
+    cmd: arg.slice(eq + 1),
+    color: COLORS[i % COLORS.length],
+  };
+});
+
+if (lanes.length === 0) {
+  console.error("usage: parallel.mjs <name>=<cmd> [<name>=<cmd> ...]");
+  process.exit(2);
+}
+
+const pad = Math.max(...lanes.map((l) => l.name.length));
+const start = performance.now();
+
+const run = (lane) =>
+  new Promise((resolve) => {
+    const tag = `${lane.color}[${lane.name.padEnd(pad)}]${RESET}`;
+    const proc = spawn(lane.cmd, { shell: true, stdio: ["ignore", "pipe", "pipe"] });
+    const ts = performance.now();
+
+    const pipe = (stream, sink) => {
+      let buf = "";
+      stream.on("data", (chunk) => {
+        buf += chunk.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          sink.write(`${tag} ${buf.slice(0, nl)}\n`);
+          buf = buf.slice(nl + 1);
+        }
+      });
+      stream.on("end", () => {
+        if (buf.length) sink.write(`${tag} ${buf}\n`);
+      });
+    };
+
+    pipe(proc.stdout, process.stdout);
+    pipe(proc.stderr, process.stderr);
+
+    proc.on("close", (code) => {
+      const elapsed = ((performance.now() - ts) / 1000).toFixed(2);
+      resolve({ ...lane, code, elapsed });
+    });
+  });
+
+const results = await Promise.all(lanes.map(run));
+const total = ((performance.now() - start) / 1000).toFixed(2);
+
+console.log("");
+console.log("─".repeat(60));
+for (const r of results) {
+  const mark = r.code === 0 ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m";
+  console.log(`${mark} ${r.name.padEnd(pad)}  ${r.elapsed}s  (exit ${r.code})`);
+}
+console.log("─".repeat(60));
+console.log(`wall time: ${total}s  (sequential would be ${results.reduce((s, r) => s + Number(r.elapsed), 0).toFixed(2)}s)`);
+
+const failed = results.filter((r) => r.code !== 0);
+if (failed.length) {
+  console.error(`\n${failed.length} lane(s) failed: ${failed.map((f) => f.name).join(", ")}`);
+  process.exit(1);
+}

--- a/scripts/scaffold-page.mjs
+++ b/scripts/scaffold-page.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Scaffold a new page (or service page) and print the exact <Route> line
+// to add to src/App.tsx. Keeps lazy-route discipline by default.
+//
+// Usage: node scripts/scaffold-page.mjs <PageName> [--service]
+
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+const args = process.argv.slice(2).filter((a) => a !== "--");
+const isService = args.includes("--service");
+const name = args.find((a) => !a.startsWith("--"));
+
+if (!name) {
+  console.error("usage: scaffold-page.mjs <PageName> [--service]");
+  process.exit(2);
+}
+
+if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) {
+  console.error(`name must be PascalCase, got: ${name}`);
+  process.exit(2);
+}
+
+const slug = name
+  .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+  .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+  .toLowerCase();
+
+const dir = isService ? "src/pages/services" : "src/pages";
+const filename = isService ? `${slug}.tsx` : `${name}.tsx`;
+const filepath = resolve(process.cwd(), dir, filename);
+
+if (existsSync(filepath)) {
+  console.error(`refusing to overwrite: ${filepath}`);
+  process.exit(1);
+}
+
+const importPath = isService ? `./pages/services/${slug}` : `./pages/${name}`;
+const routePath = isService ? `/services/${slug}` : `/${slug}`;
+
+const template = `import { Helmet } from "react-helmet-async";
+import { motion } from "framer-motion";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+
+export default function ${name}() {
+  return (
+    <>
+      <Helmet>
+        <title>${name} | Virelity.com</title>
+        <meta name="description" content="${name} — describe this page in 150 chars." />
+        <link rel="canonical" href="https://virelity.com${routePath}" />
+      </Helmet>
+
+      <Navbar />
+
+      <motion.main
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -12 }}
+        transition={{ duration: 0.4 }}
+        className="min-h-screen pt-24 pb-16"
+      >
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-6xl font-bold mb-6">${name}</h1>
+          <p className="text-lg text-muted-foreground max-w-2xl">
+            Replace this placeholder with the page content.
+          </p>
+        </div>
+      </motion.main>
+
+      <Footer />
+    </>
+  );
+}
+`;
+
+mkdirSync(dirname(filepath), { recursive: true });
+writeFileSync(filepath, template);
+
+console.log(`✓ wrote ${dir}/${filename}`);
+console.log("");
+console.log("Add this line to src/App.tsx (next to the other lazy imports):");
+console.log("");
+console.log(`  const ${name} = lazy(() => import("${importPath}"));`);
+console.log("");
+console.log("And register the route inside <Routes>:");
+console.log("");
+console.log(`  <Route path="${routePath}" element={<${name} />} />`);
+console.log("");
+console.log(`Then: npm run verify:fast`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,79 +1,88 @@
+import { lazy, Suspense } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AnimatePresence } from "framer-motion";
-import Index from "./pages/Index";
-import Portfolio from "./pages/Portfolio";
-import Utility from "./pages/Utility";
-import About from "./pages/About";
-import Team from "./pages/Team";
-import Services from "./pages/Services";
-import Contact from "./pages/Contact";
-import Career from "./pages/Career";
-import Privacy from "./pages/Privacy";
-import NotFound from "./pages/NotFound";
-import WebDevelopment from "./pages/services/web-development";
-import VRARDevelopment from "./pages/services/vr-ar-development";
-import ARVRMarketing from "./pages/services/ar-vr-marketing";
-import ThreeDDevelopment from "./pages/services/3d-development";
-import VideoEditing from "./pages/services/video-editing";
-import DesignServices from "./pages/services/design-services";
-import DigitalMarketing from "./pages/services/digital-marketing";
-import MobileApps from "./pages/services/mobile-apps";
-import UIUXDesign from "./pages/services/ui-ux-design";
-import AISolutions from "./pages/services/ai-solutions";
 import LenisSmoothScroll from "./components/LenisSmoothScroll";
 import ScrollToTop from "./components/ScrollToTop";
 import { useGoogleAnalytics } from "./hooks/use-analytics";
 import { BookingProvider } from "./contexts/BookingContext";
 import { SpeedInsights } from "@vercel/speed-insights/react";
-import { Analytics } from '@vercel/analytics/react';
-import BookPage from "./pages/book";
-import DeonMenezes from "./pages/deonmenezes";
-import Linktree from "./pages/Linktree";
-import Resources from "./pages/Resources";
-import ResourceBranch from "./pages/ResourceBranch";
+import { Analytics } from "@vercel/analytics/react";
+
+const Index = lazy(() => import("./pages/Index"));
+const Portfolio = lazy(() => import("./pages/Portfolio"));
+const Utility = lazy(() => import("./pages/Utility"));
+const About = lazy(() => import("./pages/About"));
+const Team = lazy(() => import("./pages/Team"));
+const Services = lazy(() => import("./pages/Services"));
+const Contact = lazy(() => import("./pages/Contact"));
+const Career = lazy(() => import("./pages/Career"));
+const Privacy = lazy(() => import("./pages/Privacy"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const BookPage = lazy(() => import("./pages/book"));
+const DeonMenezes = lazy(() => import("./pages/deonmenezes"));
+const Linktree = lazy(() => import("./pages/Linktree"));
+const Resources = lazy(() => import("./pages/Resources"));
+const ResourceBranch = lazy(() => import("./pages/ResourceBranch"));
+
+const WebDevelopment = lazy(() => import("./pages/services/web-development"));
+const VRARDevelopment = lazy(() => import("./pages/services/vr-ar-development"));
+const ARVRMarketing = lazy(() => import("./pages/services/ar-vr-marketing"));
+const ThreeDDevelopment = lazy(() => import("./pages/services/3d-development"));
+const VideoEditing = lazy(() => import("./pages/services/video-editing"));
+const DesignServices = lazy(() => import("./pages/services/design-services"));
+const DigitalMarketing = lazy(() => import("./pages/services/digital-marketing"));
+const MobileApps = lazy(() => import("./pages/services/mobile-apps"));
+const UIUXDesign = lazy(() => import("./pages/services/ui-ux-design"));
+const AISolutions = lazy(() => import("./pages/services/ai-solutions"));
 
 const queryClient = new QueryClient();
 
-// Component to handle Google Analytics initialization
+const RouteFallback = () => (
+  <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="h-10 w-10 rounded-full border-2 border-[#d4af37] border-t-transparent animate-spin" />
+  </div>
+);
+
 const AppWithAnalytics = () => {
   useGoogleAnalytics();
-  
+
   return (
     <AnimatePresence mode="wait">
-      <Routes>
-        <Route path="/" element={<Index />} />
-        <Route path="/portfolio" element={<Portfolio />} />
-        <Route path="/utility" element={<Utility />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/team" element={<Team />} />
-        <Route path="/services" element={<Services />} />
-        <Route path="/contact" element={<Contact />} />
-        <Route path="/career" element={<Career />} />
-        <Route path="/privacy" element={<Privacy />} />
-        <Route path="/book" element={<BookPage />} />
-        <Route path="/deonmenezes" element={<DeonMenezes />} />
-        <Route path="/linktree" element={<Linktree />} />
-        <Route path="/resources" element={<Resources />} />
-        <Route path="/resources/:branchSlug" element={<ResourceBranch />} />
-        
-        {/* Service Routes */}
-        <Route path="/services/web-development" element={<WebDevelopment />} />
-        <Route path="/services/vr-ar-development" element={<VRARDevelopment />} />
-        <Route path="/services/ar-vr-marketing" element={<ARVRMarketing />} />
-        <Route path="/services/3d-development" element={<ThreeDDevelopment />} />
-        <Route path="/services/video-editing" element={<VideoEditing />} />
-        <Route path="/services/design-services" element={<DesignServices />} />
-        <Route path="/services/digital-marketing" element={<DigitalMarketing />} />
-        <Route path="/services/mobile-apps" element={<MobileApps />} />
-        <Route path="/services/ui-ux-design" element={<UIUXDesign />} />
-        <Route path="/services/ai-solutions" element={<AISolutions />} />
+      <Suspense fallback={<RouteFallback />}>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route path="/portfolio" element={<Portfolio />} />
+          <Route path="/utility" element={<Utility />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/team" element={<Team />} />
+          <Route path="/services" element={<Services />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/career" element={<Career />} />
+          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/book" element={<BookPage />} />
+          <Route path="/deonmenezes" element={<DeonMenezes />} />
+          <Route path="/linktree" element={<Linktree />} />
+          <Route path="/resources" element={<Resources />} />
+          <Route path="/resources/:branchSlug" element={<ResourceBranch />} />
 
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+          <Route path="/services/web-development" element={<WebDevelopment />} />
+          <Route path="/services/vr-ar-development" element={<VRARDevelopment />} />
+          <Route path="/services/ar-vr-marketing" element={<ARVRMarketing />} />
+          <Route path="/services/3d-development" element={<ThreeDDevelopment />} />
+          <Route path="/services/video-editing" element={<VideoEditing />} />
+          <Route path="/services/design-services" element={<DesignServices />} />
+          <Route path="/services/digital-marketing" element={<DigitalMarketing />} />
+          <Route path="/services/mobile-apps" element={<MobileApps />} />
+          <Route path="/services/ui-ux-design" element={<UIUXDesign />} />
+          <Route path="/services/ai-solutions" element={<AISolutions />} />
+
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
     </AnimatePresence>
   );
 };
@@ -83,7 +92,7 @@ const AppContent = () => {
     <>
       <ScrollToTop />
       <AppWithAnalytics />
-      <SpeedInsights></SpeedInsights>
+      <SpeedInsights />
       <Analytics />
     </>
   );
@@ -94,7 +103,6 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      {/* Global Lenis smooth scroll */}
       <LenisSmoothScroll />
       <BookingProvider>
         <BrowserRouter>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,18 +11,32 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
+    mode === "development" && componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      // Provide a local mock for Next's `next/navigation` so packages that
-      // import it (like @vercel/speed-insights) don't break in a non-Next
-      // Vite environment. We alias both with and without the `.js` extension
-      // because some packages import `next/navigation.js` explicitly.
       "next/navigation": path.resolve(__dirname, "./src/vite-mocks/next-navigation.ts"),
       "next/navigation.js": path.resolve(__dirname, "./src/vite-mocks/next-navigation.ts"),
+    },
+  },
+  build: {
+    target: "es2020",
+    cssCodeSplit: true,
+    sourcemap: false,
+    chunkSizeWarningLimit: 1024,
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          if (!id.includes("node_modules")) return;
+          if (id.includes("three") || id.includes("@react-three") || id.includes("@splinetool")) return "three";
+          if (id.includes("framer-motion") || id.includes("lenis")) return "motion";
+          if (id.includes("@radix-ui")) return "radix";
+          if (id.includes("recharts") || id.includes("d3-")) return "charts";
+          if (id.includes("react-router") || id.includes("react-dom") || id.includes("/react/")) return "react";
+          return "vendor";
+        },
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary

- Drop in a Claude-Code multi-agent harness so day-to-day work fans out across specialised agents
- Parallelise the build pipeline (lint ‖ typecheck ‖ build) locally and in CI — wall time drops from `sum(lanes)` to `max(lanes)`
- Lazy-load every route + split heavy vendor chunks (`three`, `motion`, `radix`, `react`) so the home page no longer pulls 4.5 MB of three.js up-front

## What's added

| Path | Purpose |
|---|---|
| `CLAUDE.md` | Project map + harness contract — the file every agent reads first |
| `.claude/agents/` | 5 agents: `executor`, `designer`, `reviewer`, `seo-auditor`, `perf-auditor` |
| `.claude/commands/` | 3 slash commands: `/ship`, `/audit`, `/new-page` |
| `.claude/settings.json` | Permissions allowlist for the dev loop |
| `scripts/parallel.mjs` | Zero-dep orchestrator that fans out independent commands |
| `scripts/scaffold-page.mjs` | Page generator that emits a lazy-loaded `<Helmet>`-wired page |
| `.github/workflows/ci.yml` | 3-way parallel matrix (`lint` / `typecheck` / `build`) on PR + push |

## What's changed

- `src/App.tsx` — every page goes through `React.lazy(() => import(...))` behind a `Suspense` fallback. The previous 25 eager imports loaded the whole app on first paint.
- `vite.config.ts` — `manualChunks` splits `react`, `radix`, `motion`, `three`, `charts`, and the rest into `vendor`. `three` (4.5 MB raw / 1.4 MB gzip) is now a separate chunk that only loads on routes that use it.
- `package.json` — adds `typecheck`, `verify`, `verify:fast`, `analyze`, `clean`, `scaffold:page`. No new dependencies.
- `.gitignore` — ignores `*.tsbuildinfo` and `stats.html`.

## Bundle impact (verified locally with `npm run build`)

After:

- `dist/assets/index-…js` — **14 KB / 4.8 KB gzip** (entry)
- Each page is its own chunk (smallest 2 KB, largest 36 KB)
- `three` is now a separate chunk so the home page never loads it
- Build wall-time: 6.55s

The orchestrator's parallel speed-up was confirmed:

```
✓ A  1.02s  (exit 0)
✓ B  1.02s  (exit 0)
wall time: 1.02s  (sequential would be 2.04s)
```

## How to use

```sh
npm run verify           # lint ‖ typecheck ‖ build, parallel, aggregated
npm run verify:fast      # pre-commit speed (skips build)
npm run scaffold:page -- MyService --service
```

In Claude Code: `/ship`, `/audit`, `/new-page`.

## Pre-existing issues surfaced (not introduced by this PR)

`npm run verify:fast` shows lint and tsc errors that exist on `main`:

- 41 ESLint errors (mostly `no-explicit-any` in service pages, `no-require-imports` in `tailwind.config.ts`)
- TypeScript errors in `src/components/connect-with-us.tsx` (uses `<style jsx>`) and `src/pages/services/ar-vr-marketing.tsx` (missing `icon` field)

These exist on `main` — `vite build` skips them because it uses esbuild, not tsc. They're now visible in CI; recommend fixing in follow-up PRs (or relax `tsconfig` per-file).

## Test plan

- [ ] Pull the branch, `npm install`, `npm run verify` — confirm wall time < sequential
- [ ] `npm run dev` — load `/`, navigate to a service page, confirm Suspense fallback shows briefly then content renders
- [ ] Open Network tab — confirm `three-*.js` only loads on routes that use three.js
- [ ] Push a trivial change to confirm CI matrix runs lint/typecheck/build in parallel
- [ ] Try `/new-page MyTest --service` in Claude Code — confirm scaffold writes a page and prints the route line

🤖 Generated with [Claude Code](https://claude.com/claude-code)