### PR TITLE
Add Dubai and USA phone numbers

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -132,8 +132,9 @@ export const Footer = () => {
 
   const contactInfo = [
     { icon: MapPin, text: "Mumbai, India", href: "https://maps.app.goo.gl/sZanUiqZVm1bJ5rc6" },
-    { icon: Phone, text: "+918104796542", href: "tel:+918104796542" },
-    { icon: Phone, text: "+919167342135", href: "tel:+919167342135" },
+    { icon: Phone, text: "🇮🇳 India: +91 81047 96542", href: "tel:+918104796542" },
+    { icon: Phone, text: "🇦🇪 Dubai: +971 56 643 3640", href: "tel:+971566433640" },
+    { icon: Phone, text: "🇺🇸 USA: +1 (628) 246-6825", href: "tel:+16282466825" },
     { icon: Mail, text: "deon.menezes@virelity.com", href: "https://mail.google.com/mail/?view=cm&fs=1&to=deon.menezes@virelity.com" },
     { icon: MessageSquare, text: "WhatsApp Support", href: "https://wa.me/918104796542" },
   ];

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -179,8 +179,8 @@ const Contact = () => {
     {
       icon: Phone,
       title: "Call Us",
-      details: "+918104796542",
-      description: "Mon-Fri from 9am to 6pm",
+      details: "🇮🇳 +91 81047 96542",
+      description: "🇦🇪 +971 56 643 3640 · 🇺🇸 +1 (628) 246-6825",
       color: colors.electric,
       href: "tel:+918104796542",
     },


### PR DESCRIPTION
## Summary

Surfaces three regional contact numbers across the site:

- 🇮🇳 India: +91 81047 96542
- 🇦🇪 Dubai: +971 56 643 3640
- 🇺🇸 USA: +1 (628) 246-6825

## Where

- `src/components/Footer.tsx` — replaces the previous two India lines in the contact list with three flagged region lines, each with its own `tel:` link.
- `src/pages/Contact.tsx` — "Call Us" tile shows India as the headline number with Dubai and USA on the description line.

WhatsApp deep-links and the Contact-tile `tel:` default still point to the India primary number.

## Test plan

- [ ] `npm run dev`, scroll to footer — all three numbers render with flags, each is tappable
- [ ] Visit `/contact` — "Call Us" card shows India headline + Dubai/USA underline
- [ ] Tap each `tel:` link on a phone — confirms correct dial format

🤖 Generated with [Claude Code](https://claude.com/claude-code)